### PR TITLE
Fix setup.py for include_dirs being None

### DIFF
--- a/levmar/__init__.py
+++ b/levmar/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import division
 
 from numpy.testing import Tester as __Tester
-import _levmar
+from . import _levmar
 
 
 __version__ = '0.2.0'

--- a/levmar/_levmar.pyx
+++ b/levmar/_levmar.pyx
@@ -179,7 +179,7 @@ cdef object return_result(p, pcov, double *c_info):
 
     if int(c_info[6]) in _LM_STOP_REASONS_WARNED:
         # Issue warning for unsuccessful termination.
-        warnings.warn(_LM_STOP_REASONS[info[6]], UserWarning)
+        warnings.warn(info[3], UserWarning) 
     return p, pcov, info
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from setuptools import setup
-from distutils.extension import Extension
+from setuptools.extension import Extension
 import numpy as np
 from numpy.distutils.system_info import get_info
-
 
 levmar_sources = [
     'levmar/_levmar.c',
@@ -17,6 +16,8 @@ levmar_sources = [
     'levmar-2.6/lmbleic.c'
 ]
 
+lapack_opt = get_info('lapack_opt')
+lapack_inc = lapack_opt.pop('include_dirs', None)
 
 setup(
     name='levmar',
@@ -39,9 +40,10 @@ setup(
         Extension(
             'levmar._levmar',
             sources=levmar_sources,
-            include_dirs=['levmar-2.6', np.get_include()],
-            **get_info('lapack_opt')
+            include_dirs=['levmar-2.6', np.get_include()] + lapack_inc,
+            **lapack_opt
         ),
     ],
+    zip_safe=False,
     test_suite='nose.collector',
 )

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,10 @@ levmar_sources = [
 
 lapack_opt = get_info('lapack_opt')
 lapack_inc = lapack_opt.pop('include_dirs', None)
+include_dirs = ['levmar-2.6', np.get_include()]
+
+if lapack_inc:
+    include_dirs += lapack_inc
 
 try:
     from Cython.Distutils import build_ext
@@ -52,7 +56,7 @@ setup(
             'levmar._levmar',
             cmdclass=cmdclass,
             sources=levmar_sources,
-            include_dirs=['levmar-2.6', np.get_include()] + lapack_inc,
+            include_dirs=include_dirs,
             **lapack_opt
         ),
     ],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy.distutils.system_info import get_info
 
 levmar_sources = [
-    'levmar/_levmar.c',
     'levmar-2.6/lm.c',
     'levmar-2.6/Axb.c',
     'levmar-2.6/misc.c',
@@ -18,6 +17,18 @@ levmar_sources = [
 
 lapack_opt = get_info('lapack_opt')
 lapack_inc = lapack_opt.pop('include_dirs', None)
+
+try:
+    from Cython.Distutils import build_ext
+
+    # we have cython, cythonize source
+    levmar_sources.append('levmar/_levmar.pyx')
+    cmdclass = {'build_ext': build_ext}
+
+except ImportError:
+    # no cython, assume they can obtain _levmar.c somehow
+    levmar_sources.append('levmar/_levmar.c')
+    cmdclass = {}
 
 setup(
     name='levmar',
@@ -39,6 +50,7 @@ setup(
     ext_modules=[
         Extension(
             'levmar._levmar',
+            cmdclass=cmdclass,
             sources=levmar_sources,
             include_dirs=['levmar-2.6', np.get_include()] + lapack_inc,
             **lapack_opt


### PR DESCRIPTION
Sometimes the include dirs are `None` and this causes an error upon appending them. This commit fixes that error and compilation works on Mac OS X.
